### PR TITLE
Introduce disabling switching to alternative screen

### DIFF
--- a/glade/vte.xml.in.in
+++ b/glade/vte.xml.in.in
@@ -10,6 +10,7 @@
     <glade-widget-class title="VTE Terminal" name="VteTerminal" generic-name="terminal">
       <properties>
         <property id="allow-bold" />
+        <property id="altscreen-enabled" />
         <property id="audible-bell" />
         <property id="backspace-binding" />
         <property id="cjk-ambiguous-width" />

--- a/src/app.ui
+++ b/src/app.ui
@@ -66,6 +66,21 @@
             <property name="homogeneous">False</property>
           </packing>
         </child>
+        <child>
+          <object class="GtkToggleToolButton" id="altscreen-enabled-toolbutton">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="tooltip_text" translatable="yes">Toggle alternative screen enabled setting</property>
+            <property name="is_important">True</property>
+            <property name="action_name">win.altscreen-enabled</property>
+            <property name="label" translatable="yes">alternative Screen</property>
+            <property name="icon_name">altscreen-keyboard</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="homogeneous">False</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="expand">False</property>

--- a/src/app.vala
+++ b/src/app.vala
@@ -145,6 +145,7 @@ class Window : Gtk.ApplicationWindow
 
     /* Property actions */
     add_action(new GLib.PropertyAction ("input-enabled", terminal, "input-enabled"));
+    add_action(new GLib.PropertyAction ("altscreen-enabled", terminal, "altscreen-enabled"));
 
     /* Done! */
     box.pack_start(terminal);

--- a/src/vte-private.h
+++ b/src/vte-private.h
@@ -202,6 +202,7 @@ struct _VteTerminalPrivate {
         glong column_count;
 
 	/* Emulation setup data. */
+        gboolean altscreen_enabled;	/* switching allowed? */
 	struct _vte_matcher *matcher;	/* control sequence matcher */
 	const char *emulation;		/* terminal type to emulate */
         gboolean autowrap;              /* auto wraparound at right margin */

--- a/src/vteseq.c
+++ b/src/vteseq.c
@@ -436,12 +436,23 @@ vte_sequence_handler_normal_screen (VteTerminal *terminal, GValueArray *params)
 
         /* Make sure the ring is large enough */
         _vte_terminal_ensure_row(terminal);
+
+	/* If the alternative screen is disabled, then we didn't change */
+	/* the display, and we don't want the following restore cursor */
+	/* to do anything. This should go here, not in the save/restore */
+	/* cursor functions, since we don't want to break those. */
+
+	if (!terminal->pvt->altscreen_enabled) {
+		_vte_terminal_save_cursor(terminal, terminal->pvt->screen);
+	}
 }
 
 /* Switch to alternate screen. */
 static void
 vte_sequence_handler_alternate_screen (VteTerminal *terminal, GValueArray *params)
 {
+	if (!terminal->pvt->altscreen_enabled)
+		return;
         /* cursor.row includes insert_delta, adjust accordingly */
         terminal->pvt->cursor.row -= terminal->pvt->screen->insert_delta;
         terminal->pvt->screen = &terminal->pvt->alternate_screen;

--- a/src/vteterminal.h
+++ b/src/vteterminal.h
@@ -339,6 +339,10 @@ const char *vte_terminal_get_current_directory_uri(VteTerminal *terminal) _VTE_G
 const char *vte_terminal_get_current_file_uri(VteTerminal *terminal) _VTE_GNUC_NONNULL(1);
 
 /* misc */
+void vte_terminal_set_altscreen_enabled (VteTerminal *terminal,
+                                     gboolean enabled) _VTE_GNUC_NONNULL(1);
+gboolean vte_terminal_get_altscreen_enabled (VteTerminal *terminal) _VTE_GNUC_NONNULL(1);
+
 void vte_terminal_set_input_enabled (VteTerminal *terminal,
                                      gboolean enabled) _VTE_GNUC_NONNULL(1);
 gboolean vte_terminal_get_input_enabled (VteTerminal *terminal) _VTE_GNUC_NONNULL(1);


### PR DESCRIPTION
One thing that has kept me from using any libvte-based terminal emulators was the inability to turn of switching to the alternate screen using the decset 1047/1049 codes. Programs like vi and less use them when they start/terminate, which means whenever i look at a manual page and quit to the shell, the manpage is gone. Likewise, i edit something, quit vi, and whatever i edited is gone from the screen.

I know i can change this behaviour by changing the termcap entry - which is a hassle when you ssh around a lot - or i can change TERM to something that doesn't set ti and te - which is likely to break other stuff as well.

In XTerm, this behaviour can be controlled using the titeInhibit resource, or the middle mouse button menu. Other programs, like putty, allow to change this as well, and googling for "disable alternative screen" suggests there's a good amount of people who dislike this "feature". So, to be able to add this option to gnome-terminal, xfce-terminal, and various others, libvte needs to provide this ability, which this pull requests adds.
