### PR TITLE
Add "text/html" target to existing clipboard targets

### DIFF
--- a/glade/vte.xml.in.in
+++ b/glade/vte.xml.in.in
@@ -10,6 +10,7 @@
     <glade-widget-class title="VTE Terminal" name="VteTerminal" generic-name="terminal">
       <properties>
         <property id="allow-bold" />
+        <property id="altscreen-enabled" />
         <property id="audible-bell" />
         <property id="backspace-binding" />
         <property id="cjk-ambiguous-width" />

--- a/src/app.ui
+++ b/src/app.ui
@@ -66,6 +66,21 @@
             <property name="homogeneous">False</property>
           </packing>
         </child>
+        <child>
+          <object class="GtkToggleToolButton" id="altscreen-enabled-toolbutton">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="tooltip_text" translatable="yes">Toggle alternative screen enabled setting</property>
+            <property name="is_important">True</property>
+            <property name="action_name">win.altscreen-enabled</property>
+            <property name="label" translatable="yes">alternative Screen</property>
+            <property name="icon_name">altscreen-keyboard</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="homogeneous">False</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="expand">False</property>

--- a/src/app.vala
+++ b/src/app.vala
@@ -148,6 +148,7 @@ class Window : Gtk.ApplicationWindow
 
     /* Property actions */
     add_action(new GLib.PropertyAction ("input-enabled", terminal, "input-enabled"));
+    add_action(new GLib.PropertyAction ("altscreen-enabled", terminal, "altscreen-enabled"));
 
     /* Done! */
     box.pack_start(terminal);

--- a/src/vte-private.h
+++ b/src/vte-private.h
@@ -244,6 +244,7 @@ struct _VteTerminalPrivate {
         glong column_count;
 
 	/* Emulation setup data. */
+        gboolean altscreen_enabled;	/* switching allowed? */
 	struct _vte_matcher *matcher;	/* control sequence matcher */
 	const char *emulation;		/* terminal type to emulate */
         gboolean autowrap;              /* auto wraparound at right margin */

--- a/src/vte.c
+++ b/src/vte.c
@@ -87,6 +87,10 @@ typedef gunichar wint_t;
 static int _vte_unichar_width(gunichar c, int utf8_ambiguous_width);
 static void vte_terminal_set_visibility (VteTerminal *terminal, GdkVisibilityState state);
 static void vte_terminal_paste(VteTerminal *terminal, GdkAtom board);
+static void clipboard_get_data(GtkClipboard* clipboard,
+                          GtkSelectionData* sd,
+                          guint info,
+                          gpointer user_data);
 static void vte_terminal_real_copy_clipboard(VteTerminal *terminal);
 static void vte_terminal_real_paste_clipboard(VteTerminal *terminal);
 static gboolean vte_terminal_io_read(GIOChannel *channel,
@@ -11411,14 +11415,44 @@ vte_terminal_get_rewrap_on_resize(VteTerminal *terminal)
 }
 
 static void
+clipboard_get_data(GtkClipboard* clipboard,
+                          GtkSelectionData* sd,
+                          guint info,
+                          gpointer user_data)
+{
+        gchar *html_data;
+        GdkAtom html_target = gdk_atom_intern( "text/html", FALSE );
+
+        if (gtk_selection_data_get_target(sd) == html_target) {
+                html_data = g_strdup_printf("<meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\"><pre style=\"color: #ffffff; background-color: #000000;\">%s</pre>", (gchar *)user_data);
+                gtk_selection_data_set(sd, html_target, 8, (guchar *)html_data, strlen(html_data));
+                g_free(html_data);
+        } else {
+                gtk_selection_data_set_text (sd, user_data, -1);
+        }
+}
+
+static void
 vte_terminal_real_copy_clipboard(VteTerminal *terminal)
 {
 	_vte_debug_print(VTE_DEBUG_SELECTION, "Copying to CLIPBOARD.\n");
 	if (terminal->pvt->selection != NULL) {
 		GtkClipboard *clipboard;
-		clipboard = vte_terminal_clipboard_get(terminal,
-						       GDK_SELECTION_CLIPBOARD);
-		gtk_clipboard_set_text(clipboard, terminal->pvt->selection, -1);
+		GtkTargetList *target_list;
+		GtkTargetEntry *targets;
+		gint n_targets;
+		GdkAtom html_target = gdk_atom_intern( "text/html", FALSE );
+
+		target_list = gtk_target_list_new (NULL, 0);
+		gtk_target_list_add_text_targets (target_list, 0);
+		gtk_target_list_add(target_list, html_target, 0, 1);
+		targets = gtk_target_table_new_from_list (target_list, &n_targets);
+
+		clipboard = vte_terminal_clipboard_get (terminal, GDK_SELECTION_CLIPBOARD);
+		gtk_clipboard_set_with_data (clipboard, targets, n_targets, clipboard_get_data, NULL,
+				terminal->pvt->selection);
+		g_free (targets);
+		gtk_target_list_unref (target_list);
 	}
 }
 

--- a/src/vte.c
+++ b/src/vte.c
@@ -91,6 +91,7 @@ static void clipboard_get_data(GtkClipboard* clipboard,
                           GtkSelectionData* sd,
                           guint info,
                           gpointer user_data);
+static void clipboard_clean_data(GtkClipboard *clipboard, gpointer user_data);
 static void vte_terminal_real_copy_clipboard(VteTerminal *terminal);
 static void vte_terminal_real_paste_clipboard(VteTerminal *terminal);
 static gboolean vte_terminal_io_read(GIOChannel *channel,
@@ -11433,6 +11434,12 @@ clipboard_get_data(GtkClipboard* clipboard,
 }
 
 static void
+clipboard_clean_data(GtkClipboard *clipboard, gpointer user_data)
+{
+	g_free(user_data);
+}
+
+static void
 vte_terminal_real_copy_clipboard(VteTerminal *terminal)
 {
 	_vte_debug_print(VTE_DEBUG_SELECTION, "Copying to CLIPBOARD.\n");
@@ -11449,8 +11456,8 @@ vte_terminal_real_copy_clipboard(VteTerminal *terminal)
 		targets = gtk_target_table_new_from_list (target_list, &n_targets);
 
 		clipboard = vte_terminal_clipboard_get (terminal, GDK_SELECTION_CLIPBOARD);
-		gtk_clipboard_set_with_data (clipboard, targets, n_targets, clipboard_get_data, NULL,
-				terminal->pvt->selection);
+		gtk_clipboard_set_with_data (clipboard, targets, n_targets, clipboard_get_data, clipboard_clean_data,
+				g_strdup(terminal->pvt->selection));
 		g_free (targets);
 		gtk_target_list_unref (target_list);
 	}

--- a/src/vte.c
+++ b/src/vte.c
@@ -161,6 +161,7 @@ enum {
         PROP_HSCROLL_POLICY,
         PROP_VSCROLL_POLICY,
         PROP_ALLOW_BOLD,
+        PROP_ALTSCREEN_ENABLED,
         PROP_AUDIBLE_BELL,
         PROP_BACKSPACE_BINDING,
         PROP_CJK_AMBIGUOUS_WIDTH,
@@ -8201,6 +8202,7 @@ vte_terminal_init(VteTerminal *terminal)
 	vte_terminal_set_default_tabstops(terminal);
 
         pvt->input_enabled = TRUE;
+        pvt->altscreen_enabled = TRUE;
 
 	/* Cursor shape. */
 	pvt->cursor_shape = VTE_CURSOR_SHAPE_BLOCK;
@@ -10157,6 +10159,9 @@ vte_terminal_get_property (GObject *object,
                 case PROP_ALLOW_BOLD:
                         g_value_set_boolean (value, vte_terminal_get_allow_bold (terminal));
                         break;
+                case PROP_ALTSCREEN_ENABLED:
+                        g_value_set_boolean (value, vte_terminal_get_altscreen_enabled (terminal));
+                        break;
                 case PROP_AUDIBLE_BELL:
                         g_value_set_boolean (value, vte_terminal_get_audible_bell (terminal));
                         break;
@@ -10254,6 +10259,9 @@ vte_terminal_set_property (GObject *object,
                         break;
                 case PROP_ALLOW_BOLD:
                         vte_terminal_set_allow_bold (terminal, g_value_get_boolean (value));
+                        break;
+                case PROP_ALTSCREEN_ENABLED:
+                        vte_terminal_set_altscreen_enabled (terminal, g_value_get_boolean (value));
                         break;
                 case PROP_AUDIBLE_BELL:
                         vte_terminal_set_audible_bell (terminal, g_value_get_boolean (value));
@@ -10926,6 +10934,18 @@ vte_terminal_class_init(VteTerminalClass *klass)
                                        TRUE,
                                        (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY)));
      
+        /**
+         * VteTerminal:altscreen-enabled:
+         *
+         * Controls whether the terminal allows switching to the alternate
+	 * screen.
+         */
+        g_object_class_install_property
+                (gobject_class,
+                 PROP_ALTSCREEN_ENABLED,
+                 g_param_spec_boolean ("altscreen-enabled", NULL, NULL,
+                                       TRUE,
+                                       G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY));
         /**
          * VteTerminal:audible-bell:
          *
@@ -13353,6 +13373,75 @@ vte_terminal_set_geometry_hints_for_window(VteTerminal *terminal,
                                       (GdkWindowHints)(GDK_HINT_RESIZE_INC |
                                                        GDK_HINT_MIN_SIZE |
                                                        GDK_HINT_BASE_SIZE));
+}
+
+/**
+ * vte_terminal_set_altscreen_enabled:
+ * @terminal: a #VteTerminal
+ * @enabled: whether to enable the alternative screen
+ *
+ * Enables or disables switching to the alternative screen
+ */
+void
+vte_terminal_set_altscreen_enabled (VteTerminal *terminal,
+                                gboolean enabled)
+{
+        VteTerminalPrivate *pvt;
+        GtkWidget *widget;
+        GtkStyleContext *context;
+
+        g_return_if_fail(VTE_IS_TERMINAL(terminal));
+
+        pvt = terminal->pvt;
+        widget = &terminal->widget;
+
+        enabled = enabled != FALSE;
+        if (enabled == terminal->pvt->altscreen_enabled)
+                return;
+
+#if 0
+	/* It's probably better not to do anything here.
+	 * If the screen is still switched to the alternative one,
+	 * switching back will only confuse the user. Since the
+	 * flag disables switching to the alternative only,
+	 * but does not disable switching back, the switch
+	 * back will occur normally when the user exits the
+	 * application / sends the te sequence.
+	 */
+
+	if (pvt->altscreen_enabled && !enabled) {
+		/* If we disable the alternative screen, switch back to */
+		/* the normal one. Note that, if the current application */
+		/* has switched to the alternative screen, this will */
+		/* hide the current application. */
+		/* This is copied from vte_sequence_handler_normal_screen */
+		/* in vteseq.c, which is a static_function there. */
+		/* cursor.row includes insert_delta, adjust accordingly */
+		pvt->cursor.row -= pvt->screen->insert_delta;
+		pvt->screen = &pvt->normal_screen;
+		pvt->cursor.row += pvt->screen->insert_delta;
+
+		/* Make sure the ring is large enough */
+		_vte_terminal_ensure_row(terminal);
+	}
+#endif
+
+        pvt->altscreen_enabled = enabled;
+        g_object_notify(G_OBJECT(terminal), "altscreen-enabled");
+}
+
+/**
+ * vte_terminal_get_altscreen_enabled:
+ * @terminal: a #VteTerminal
+ *
+ * Returns whether the terminal allows switching to the alternative screen.
+ */
+gboolean
+vte_terminal_get_altscreen_enabled (VteTerminal *terminal)
+{
+        g_return_val_if_fail(VTE_IS_TERMINAL(terminal), FALSE);
+
+        return terminal->pvt->altscreen_enabled;
 }
 
 /**

--- a/src/vte/vteterminal.h
+++ b/src/vte/vteterminal.h
@@ -344,6 +344,10 @@ const char *vte_terminal_get_current_directory_uri(VteTerminal *terminal) _VTE_G
 const char *vte_terminal_get_current_file_uri(VteTerminal *terminal) _VTE_GNUC_NONNULL(1);
 
 /* misc */
+void vte_terminal_set_altscreen_enabled (VteTerminal *terminal,
+                                     gboolean enabled) _VTE_GNUC_NONNULL(1);
+gboolean vte_terminal_get_altscreen_enabled (VteTerminal *terminal) _VTE_GNUC_NONNULL(1);
+
 void vte_terminal_set_input_enabled (VteTerminal *terminal,
                                      gboolean enabled) _VTE_GNUC_NONNULL(1);
 gboolean vte_terminal_get_input_enabled (VteTerminal *terminal) _VTE_GNUC_NONNULL(1);

--- a/src/vteseq.c
+++ b/src/vteseq.c
@@ -441,12 +441,23 @@ vte_sequence_handler_normal_screen (VteTerminal *terminal, GValueArray *params)
 
         /* Make sure the ring is large enough */
         _vte_terminal_ensure_row(terminal);
+
+	/* If the alternative screen is disabled, then we didn't change */
+	/* the display, and we don't want the following restore cursor */
+	/* to do anything. This should go here, not in the save/restore */
+	/* cursor functions, since we don't want to break those. */
+
+	if (!terminal->pvt->altscreen_enabled) {
+		_vte_terminal_save_cursor(terminal, terminal->pvt->screen);
+	}
 }
 
 /* Switch to alternate screen. */
 static void
 vte_sequence_handler_alternate_screen (VteTerminal *terminal, GValueArray *params)
 {
+	if (!terminal->pvt->altscreen_enabled)
+		return;
         /* cursor.row includes insert_delta, adjust accordingly */
         terminal->pvt->cursor.row -= terminal->pvt->screen->insert_delta;
         terminal->pvt->screen = &terminal->pvt->alternate_screen;


### PR DESCRIPTION
This allows copying terminal output to a "text/html" target which allows pasting into a client supporting HTML (eg. GMail).

It makes the ouput a lot more readable (and properly aligned) in an HMTL email or other html client.

Note: emulates what Mac OSX terminal does when copying it's output to the system clipboard.
