### PR TITLE
cp437.py: Python 3 compatibility

### DIFF
--- a/src/cp437.py
+++ b/src/cp437.py
@@ -1,9 +1,22 @@
 #!/usr/bin/python
-print '%s' % '(U'
+from __future__ import print_function
+import sys
+if sys.version_info > (3,):
+    PY3 = True
+    two_bytes = bytearray(b'\x00\x20')
+else:
+    PY3 = False
+print('%s' % '(U')
 i = 128
 while (i < 256):
-	print "%c" % i,
-	if ((i % 32) == 31):
-		print ""
-	i = i + 1
-print '%s' % '(B)0*B+B'
+    if PY3:
+        # avoid encoding of print function
+        two_bytes[0] = i
+        sys.stdout.flush()
+        sys.stdout.buffer.write(two_bytes)
+    else:
+        print("%c" % i, end=' ')
+    if ((i % 32) == 31):
+        print("")
+    i = i + 1
+print('%s' % '(B)0*B+B')


### PR DESCRIPTION
Both Python 2 and Python 3 compatible code, tested with Python 2.7 and Python 3.4 in Fedora 22. It should work with Python 2.6 and 2.7 as well as with Python 3.2 and higher.