### PR TITLE
Add AC_CONFIG_AUX_DIR to make sure ltmain.sh is copied to the right directory

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_INIT([vte],
         [version_triplet],
         [http://bugzilla.gnome.org/enter_bug.cgi?product=vte],
         [vte])
-
+AC_CONFIG_AUX_DIR([.])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([src/vteapp.c])
 AC_CONFIG_HEADERS([config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,7 @@ AC_INIT([vte],
         [version_triplet],
         [http://bugzilla.gnome.org/enter_bug.cgi?product=vte],
         [vte])
+	
 AC_CONFIG_AUX_DIR([.])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([src/vteapp.c])


### PR DESCRIPTION
Currently, cloning vte-ng and running autogen.sh produces the following log:

autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I m4
autoreconf: configure.ac: tracing
autoreconf: running: libtoolize --copy --force
libtoolize: putting auxiliary files in '..'.
libtoolize: copying file '../ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
autoreconf: running: /usr/bin/autoconf --force
autoreconf: running: /usr/bin/autoheader --force
autoreconf: running: automake --add-missing --copy --force-missing
configure.ac:57: installing './compile'
configure.ac:70: installing './config.guess'
configure.ac:70: installing './config.sub'
configure.ac:16: installing './install-sh'
configure.ac:70: error: required file './ltmain.sh' not found
configure.ac:16: installing './missing'
doc/openi18n/Makefile.am: installing './depcomp'
parallel-tests: installing './test-driver'
autoreconf: automake failed with exit status: 1
The key line in the above log is libtoolize: putting auxiliary files in '..'..

Somehow, ltmain.sh is not being copied to the right directory. Interestingly enough, running autogen.sh a second time corrects this issue, copying to the current folder.

This PR fixes the issue by adding flags to explicitly set auxiliary directory as the current directory.